### PR TITLE
Added `errorMessage` to error message parsing

### DIFF
--- a/Connection/RESTConnector.cs
+++ b/Connection/RESTConnector.cs
@@ -655,6 +655,11 @@ namespace IBM.Cloud.SDK.Connection
                 return deserializedObject["message"];
             }
 
+            if ((deserializedObject as Dictionary<string, object>).ContainsKey("errorMessage"))
+            {
+                return deserializedObject["errorMessage"];
+            }
+
             return "Unknown error";
         }
         #endregion

--- a/Tests/CoreTests.cs
+++ b/Tests/CoreTests.cs
@@ -50,5 +50,14 @@ namespace IBM.Cloud.SDK.Tests
             string errorMessage = restConnector.GetErrorMessage(json);
             Assert.IsTrue(errorMessage == "string");
         }
+
+        [Test]
+        public void GetErrorFromErrorMessage()
+        {
+            string json = "{\"code\":\"string\",\"errorMessage\":\"string\"}";
+            RESTConnector restConnector = new RESTConnector();
+            string errorMessage = restConnector.GetErrorMessage(json);
+            Assert.IsTrue(errorMessage == "string");
+        }
     }
 }


### PR DESCRIPTION
#### Summary
This pull request adds `errorMessage` to the error message parsing for errors coming from the IAM service.