### PR TITLE
Look for iam_apikey in credential file for IAM auth

### DIFF
--- a/BaseService.cs
+++ b/BaseService.cs
@@ -41,6 +41,10 @@ namespace IBM.Cloud.SDK
                 }
 
                 string ApiKey = Environment.GetEnvironmentVariable(serviceId.ToUpper() + "_IAM_APIKEY");
+                // check for old IAM API key name as well
+                if (string.IsNullOrEmpty(apiKey)) {
+                    apiKey = Environment.GetEnvironmentVariable(ServiceName.ToUpper() + "_APIKEY");
+                }
                 string Username = Environment.GetEnvironmentVariable(serviceId.ToUpper() + "_USERNAME");
                 string Password = Environment.GetEnvironmentVariable(serviceId.ToUpper() + "_PASSWORD");
                 string ServiceUrl = Environment.GetEnvironmentVariable(serviceId.ToUpper() + "_URL");

--- a/BaseService.cs
+++ b/BaseService.cs
@@ -40,7 +40,7 @@ namespace IBM.Cloud.SDK
                     }
                 }
 
-                string ApiKey = Environment.GetEnvironmentVariable(serviceId.ToUpper() + "_APIKEY");
+                string ApiKey = Environment.GetEnvironmentVariable(serviceId.ToUpper() + "_IAM_APIKEY");
                 string Username = Environment.GetEnvironmentVariable(serviceId.ToUpper() + "_USERNAME");
                 string Password = Environment.GetEnvironmentVariable(serviceId.ToUpper() + "_PASSWORD");
                 string ServiceUrl = Environment.GetEnvironmentVariable(serviceId.ToUpper() + "_URL");


### PR DESCRIPTION
Related to an internal naming debate. Basically, we've decided we should be using `iam_apikey` for IAM keys and are updating code on the IBM Cloud side to adhere to this. This will then require updating on the SDK side to capture those changes.

In this PR, we still do look for the old `apikey` name so as not to break anyone who may have been using an old credential file.