### PR TITLE
feat: make connectors settable to use them in unit tests

### DIFF
--- a/BaseService.cs
+++ b/BaseService.cs
@@ -31,6 +31,19 @@ namespace IBM.Cloud.SDK
         /// Gets and sets the authenticator of the service.
         public Authenticator Authenticator { get; set; }
         #endregion
+
+        #region Connector
+        private RESTConnector _connector;
+        /// <summary>
+        /// Gets and sets the Connector of the service.
+        /// </summary>
+        public RESTConnector Connector
+        {
+            get { return _connector; }
+            set { _connector = value; }
+        }
+        #endregion
+
         protected string serviceUrl;
         public string ServiceId { get; set; }
         protected Dictionary<string, string> customRequestHeaders = new Dictionary<string, string>();
@@ -51,6 +64,18 @@ namespace IBM.Cloud.SDK
             {
                 SetServiceUrl(url);
             }
+
+            if (string.IsNullOrEmpty(GetServiceUrl()))
+            {
+                throw new ArgumentNullException("The serviceUrl must not be empty or null.");
+            }
+
+            if (Utility.HasBadFirstOrLastCharacter(GetServiceUrl()))
+            {
+                throw new ArgumentException("The serviceUrl property is invalid. Please remove any surrounding {{, }}, or \" characters.");
+            }
+
+            Connector = new RESTConnector();
         }
 
         public void SetServiceUrl(string url)

--- a/Connection/RESTConnector.cs
+++ b/Connection/RESTConnector.cs
@@ -293,7 +293,7 @@ namespace IBM.Cloud.SDK.Connection
         /// </summary>
         /// <param name="request">The request object.</param>
         /// <returns>true is returned on success, false is returned if the Request can't be sent.</returns>
-        public bool Send(Request request)
+        public virtual bool Send(Request request)
         {
             if (request == null)
             {
@@ -326,7 +326,7 @@ namespace IBM.Cloud.SDK.Connection
             {
                Headers = new Dictionary<string,string>();;
             }
-            Headers.Add(AUTHENTICATION_AUTHORIZATION_HEADER, string.Format("Bearer {0}", bearerToken));
+            Headers[AUTHENTICATION_AUTHORIZATION_HEADER] = string.Format("Bearer {0}", bearerToken);
         }
 
         /// <summary>
@@ -340,7 +340,7 @@ namespace IBM.Cloud.SDK.Connection
             {
                Headers = new Dictionary<string,string>();;
             }
-            Headers.Add(AUTHENTICATION_AUTHORIZATION_HEADER, Utility.CreateAuthorization(username, password));
+            Headers[AUTHENTICATION_AUTHORIZATION_HEADER] = Utility.CreateAuthorization(username, password);
         }
         #endregion
 


### PR DESCRIPTION
This PR:

- Adds `Connector` setter to base service
- Add check for `serviceUrl` in base service because we will bot use `GetConnector` any more for `RESTConnector` and we will retire it in next major release.