### PR TITLE
fix: allow '=' character in environment config values

### DIFF
--- a/Tests/CredentialUtilsTests.cs
+++ b/Tests/CredentialUtilsTests.cs
@@ -33,6 +33,7 @@ namespace IBM.Cloud.SDK.Tests
         public void TestGetVcapCredentialsAsMap()
         {
             var apikey = "bogus-apikey";
+            var service1_apikey = "V4HXmoUtMjohnsnow=KotN";
             var tempVcapCredential = new Dictionary<string, List<VcapCredential>>();
             var vcapCredential = new VcapCredential()
             {
@@ -41,7 +42,18 @@ namespace IBM.Cloud.SDK.Tests
                     ApiKey = apikey
                 }
             };
+
+            var vcapCredential2 = new VcapCredential()
+            {
+                Credentials = new Credential()
+                {
+                    ApiKey = service1_apikey
+                }
+            };
+
+            vcapCredential2.Name = "equals_sign_test";
             tempVcapCredential.Add("assistant", new List<VcapCredential>() { vcapCredential });
+            tempVcapCredential.Add("equals_sign_test", new List<VcapCredential>() { vcapCredential2 });
 
             var vcapString = JsonConvert.SerializeObject(tempVcapCredential);
             Environment.SetEnvironmentVariable("VCAP_SERVICES", vcapString);
@@ -53,6 +65,13 @@ namespace IBM.Cloud.SDK.Tests
                 Authenticator.PropNameApikey,
                 out string extractedKey);
             Assert.IsTrue(extractedKey == apikey);
+
+            vcapCredentaialsAsMap = CredentialUtils.GetVcapCredentialsAsMap("equals_sign_test");
+            Assert.IsNotNull(vcapCredentaialsAsMap);
+            vcapCredentaialsAsMap.TryGetValue(
+                Authenticator.PropNameApikey,
+                out string extractedKey2);
+            Assert.IsTrue(extractedKey2 == service1_apikey);
         }
 
         [Test]
@@ -413,6 +432,100 @@ namespace IBM.Cloud.SDK.Tests
             var serviceProperties = CredentialUtils.GetServiceProperties("assistant");
 
             Assert.IsNotNull(serviceProperties);
+        }
+
+        [Test]
+        public void TestGetFileCredentialsAsMapService1()
+        {
+            // store and clear user set env variable
+            string ibmCredFile = Environment.GetEnvironmentVariable("IBM_CREDENTIALS_FILE");
+            Environment.SetEnvironmentVariable("IBM_CREDENTIALS_FILE", "");
+
+            //  create .env file in current directory
+            string[] linesWorking = { "SERVICE_1_AUTH_TYPE=iam",
+                                      "SERVICE_1_APIKEY=V4HXmoUtMjohnsnow=KotN",
+                                      "SERVICE_1_CLIENT_ID=somefake========id",
+                                      "SERVICE_1_CLIENT_SECRET===my-client-secret==",
+                                      "SERVICE_1_AUTH_URL=https://iamhost/iam/api=",
+                                      "SERVICE_1_AUTH_DISABLE_SSL=" };
+            var directoryPath = Directory.GetCurrentDirectory();
+            var credsFile = Path.Combine(directoryPath, "ibm-credentials.env");
+
+            using (StreamWriter outputFile = new StreamWriter(credsFile))
+            {
+                foreach (string line in linesWorking)
+                {
+                    outputFile.WriteLine(line);
+                }
+            }
+
+            //  get props
+            Dictionary<string, string> propsWorking = CredentialUtils.GetFileCredentialsAsMap("service_1");
+            Assert.IsNotNull(propsWorking);
+            Assert.AreEqual(propsWorking["AUTH_TYPE"], "iam");
+            Assert.AreEqual(propsWorking["APIKEY"], "V4HXmoUtMjohnsnow=KotN");
+            Assert.AreEqual(propsWorking["CLIENT_ID"], "somefake========id");
+            Assert.AreEqual(propsWorking["CLIENT_SECRET"], "==my-client-secret==");
+            Assert.AreEqual(propsWorking["AUTH_URL"], "https://iamhost/iam/api=");
+            Assert.IsFalse(propsWorking.ContainsKey("DISABLE_SSL"));
+            //  delete created env files
+            if (File.Exists(credsFile))
+            {
+                File.Delete(credsFile);
+            }
+            //  reset env variable
+            Environment.SetEnvironmentVariable("IBM_CREDENTIALS_FILE", ibmCredFile);
+        }
+
+        [Test]
+        public void TestGetEnvCredentialsAsMapService1()
+        {
+            var apikey = "V4HXmoUtMjohnsnow=KotN";
+            var authType = "iam";
+            var clientId = "somefake========id";
+            var clientIdSecret = "==my-client-secret==";
+            var authUrl = "https://iamhost/iam/api=";
+
+            Environment.SetEnvironmentVariable(
+                "SERVICE_1_" + Authenticator.PropNameApikey,
+                apikey);
+            Environment.SetEnvironmentVariable(
+                "SERVICE_1_" + Authenticator.PropNameAuthType,
+                authType);
+            Environment.SetEnvironmentVariable(
+                "SERVICE_1_" + Authenticator.PropNameClientId,
+                clientId);
+            Environment.SetEnvironmentVariable(
+                "SERVICE_1_" + Authenticator.PropNameClientSecret,
+                clientIdSecret);
+            Environment.SetEnvironmentVariable(
+                "SERVICE_1_" + Authenticator.PropNameUrl,
+                authUrl);
+            // get props
+            Dictionary<string, string> props = CredentialUtils.GetEnvCredentialsAsMap("service_1");
+            Assert.IsNotNull(props);
+            Assert.AreEqual(props["AUTH_TYPE"], authType);
+            Assert.AreEqual(props["APIKEY"], apikey);
+            Assert.AreEqual(props["CLIENT_ID"], clientId);
+            Assert.AreEqual(props["CLIENT_SECRET"], clientIdSecret);
+            Assert.AreEqual(props["AUTH_URL"], authUrl);
+
+            //  delete created env files
+            Environment.SetEnvironmentVariable(
+               "SERVICE_1_" + Authenticator.PropNameApikey,
+               null);
+            Environment.SetEnvironmentVariable(
+                "SERVICE_1_" + Authenticator.PropNameAuthType,
+                null);
+            Environment.SetEnvironmentVariable(
+                "SERVICE_1_" + Authenticator.PropNameClientId,
+                null);
+            Environment.SetEnvironmentVariable(
+                "SERVICE_1_" + Authenticator.PropNameClientSecret,
+                null);
+            Environment.SetEnvironmentVariable(
+                "SERVICE_1_" + Authenticator.PropNameUrl,
+                null);
         }
     }
 }

--- a/Utilities/CredentialUtils.cs
+++ b/Utilities/CredentialUtils.cs
@@ -342,7 +342,7 @@ namespace IBM.Cloud.SDK.Utilities
                 }
 
                 string[] stringSeparators = new string[] { "=" };
-                List<string> lineTokens = new List<string>(line.Split(stringSeparators, StringSplitOptions.None));
+                List<string> lineTokens = new List<string>(line.Split(stringSeparators, 2, StringSplitOptions.None));
                 if (lineTokens.Count != 2)
                 {
                     continue;


### PR DESCRIPTION
ref: https://github.ibm.com/arf/planning-sdk-squad/issues/1759

Changes:
- allow for a env config property's value to contain the ``=`` character
- add unit test cases