### PR TITLE
fix: assign an empty dictionary to RESTConnector's resp.headers if null

### DIFF
--- a/Connection/RESTConnector.cs
+++ b/Connection/RESTConnector.cs
@@ -631,7 +631,7 @@ namespace IBM.Cloud.SDK.Connection
                     resp.Error = error;
                 }
 
-                resp.Headers = unityWebRequest.GetResponseHeaders();
+                resp.Headers = unityWebRequest.GetResponseHeaders() ?? new Dictionary<string, string>();
 
                 resp.ElapsedTime = (float)(DateTime.Now - startTime).TotalSeconds;
 


### PR DESCRIPTION
Almost every RESTConnector callback has a loop like this:

    foreach (KeyValuePair<string, string> kvp in resp.Headers)
    {
        response.Headers.Add(kvp.Key, kvp.Value);
    }

The problem is that when there are no response header, such as when a network error happens, response headers can be null, what I did here is assign an empty dictionary if null, so the loop never throws.

The better solution is a null check before the loop, or maybe a try-catch, after all there are [only](https://github.com/IBM/unity-sdk-core/blob/e0d903834d6684f16bde2ed2eb2d57540138c1b1/Authentication/CloudPakForData/CloudPakForDataAuthenticator.cs#L168) [two](https://github.com/IBM/unity-sdk-core/blob/e0d903834d6684f16bde2ed2eb2d57540138c1b1/Authentication/Iam/IamAuthenticator.cs#L203) instances of this in this repository... but there are 246 copy-pasted instances of this in Watson's Unity SDK, so, actually, the better solution is to refactor the code, maybe make a generic response handler that all of these can use, or, even better, make it the default handler for RESTConnector.

But to refactor the code I need to make changes to multiple repositories, including AllCaps(246) modifications to watson sdk, so although it pains me to generate more work for the garbage collector, I thought this is a very clean and small solution to the problem.