### PR TITLE
fix(build): main migration automation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,3 +32,5 @@ deploy:
   - provider: script
     skip_cleanup: true
     script: npx semantic-release
+    on:
+      branch: main


### PR DESCRIPTION
At present, the default for a deployment build is `master` in Travis.  This PR upgrades this to explicitly use `main`.