### PR TITLE
fix(rest-connector): add an extra request on the else statement

### DIFF
--- a/Connection/RESTConnector.cs
+++ b/Connection/RESTConnector.cs
@@ -488,16 +488,21 @@ namespace IBM.Cloud.SDK.Connection
                         {
                             Log.Error("RESTConnector.ProcessRequestQueue()", "Exception when initializing WWWForm: {0}", e.ToString());
                         }
+
                         if (req.HttpMethod == UnityWebRequest.kHttpVerbPUT) 
                         {
                             unityWebRequest = UnityWebRequest.Post(url, form);   
                             unityWebRequest.method = "PUT";
                         }
-                        else
+                        else if(req.HttpMethod == UnityWebRequest.kHttpVerbPOST)
                         {
                             var httpContent = bodyObject.ToString();
                             unityWebRequest = UnityWebRequest.Put(url, httpContent);     
                             unityWebRequest.method = "POST";
+                        }
+                        else 
+                        {
+                            unityWebRequest = UnityWebRequest.Post(url, form);
                         }
                     }
                     else if (req.Send != null)

--- a/Connection/RESTConnector.cs
+++ b/Connection/RESTConnector.cs
@@ -494,7 +494,7 @@ namespace IBM.Cloud.SDK.Connection
                             unityWebRequest = UnityWebRequest.Post(url, form);   
                             unityWebRequest.method = "PUT";
                         }
-                        else if(req.HttpMethod == UnityWebRequest.kHttpVerbPOST)
+                        else if (req.HttpMethod == UnityWebRequest.kHttpVerbPOST)
                         {
                             var httpContent = bodyObject.ToString();
                             unityWebRequest = UnityWebRequest.Put(url, httpContent);     


### PR DESCRIPTION
the post request needs to use httpcontent just in case if it is dealing with files. The else
statement also uses Post, but it is pretty much allowing the use of other requests such as GET
(UnityWebRequest.Post makes it work for GET requests).